### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Enable fast, free real-time web search and access premium data from trusted medi
 
 <br>
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/dappierai-dappier-mcp).
+
 ## Getting Started
 
 Get Dappier API Key. Head to [Dappier](https://platform.dappier.com/profile/api-keys) to sign up and generate an API key.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/dappierai-dappier-mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Hosted deployment" section to README with a link to access the hosted version of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->